### PR TITLE
Update to Unity 5.x

### DIFF
--- a/LogOutputHandler.cs
+++ b/LogOutputHandler.cs
@@ -1,38 +1,41 @@
-﻿/// <summary>
-/// Basic controller that takes logs from Unity's debug.log function and sends output to Loggly
-/// </summary>
-/// USAGE: Simply put this script in your scripts folder and it will operate.
-/// Created by Mike Turner of Charmed Matter Games.
-
 using UnityEngine;
 using System.Collections;
 
 public class LogOutputHandler : MonoBehaviour {
 
-	//Register the HandleLog function on scene start to fire on debug.log events 
-	void Awake(){
-		Application.RegisterLogCallback(HandleLog);
-	} 
-	
-	//Create a string to store log level in
-	string level = "";
-	
-	//Capture debug.log output, send logs to Loggly
-	public void HandleLog(string logString, string stackTrace, LogType type) {
-	
-		//Initialize WWWForm and store log level as a string
-		level = type.ToString ();
-		var loggingForm = new WWWForm();
-		
-		//Add log message to WWWForm
-		loggingForm.AddField("LEVEL", level);
-		loggingForm.AddField("Message", logString);
-		loggingForm.AddField("Stack_Trace", stackTrace);
-		
-        	//Add any User, Game, or Device MetaData that would be useful to finding issues later 
-		loggingForm.AddField("Device_Model", SystemInfo.deviceModel);
-		
-		//Send WWW Form to Loggly, replace TOKEN with your unique ID from Loggly
-		var sendLog = new WWW("http://logs-01.loggly.com/inputs/TOKEN/tag/http/", loggingForm);
-	}
+    //Register the HandleLog function on scene start to fire on debug.log events
+    public void OnEnable(){
+				Application.logMessageReceived += HandleLog;
+    }
+
+    //Remove callback when object goes out of scope
+		public void OnDisable(){
+				Application.logMessageReceived -= HandleLog;
+    }
+
+    //Create a string to store log level in
+    string level = "";
+
+    //Capture debug.log output, send logs to Loggly
+    public void HandleLog(string logString, string stackTrace, LogType type) {
+
+        //Initialize WWWForm and store log level as a string
+        level = type.ToString ();
+        var loggingForm = new WWWForm();
+
+        //Add log message to WWWForm
+        loggingForm.AddField("LEVEL", level);
+        loggingForm.AddField("Message", logString);
+        loggingForm.AddField("Stack_Trace", stackTrace);
+
+        //Add any User, Game, or Device MetaData that would be useful to finding issues later
+        loggingForm.AddField("Device_Model", SystemInfo.deviceModel);
+				StartCoroutine(SendData(loggingForm));
+		}
+
+		public IEnumerator SendData(WWWForm form){
+        //Send WWW Form to Loggly, replace TOKEN with your unique ID from Loggly
+        WWW sendLog = new WWW("http://logs-01.loggly.com/inputs/TOKEN/tag/Unity3D", form);
+				yield return sendLog;
+    }
 }

--- a/LogOutputHandler.cs
+++ b/LogOutputHandler.cs
@@ -9,7 +9,7 @@ public class LogOutputHandler : MonoBehaviour {
     }
 
     //Remove callback when object goes out of scope
-	public void OnDisable(){
+    public void OnDisable(){
 	    Application.logMessageReceived -= HandleLog;
     }
 
@@ -19,23 +19,23 @@ public class LogOutputHandler : MonoBehaviour {
     //Capture debug.log output, send logs to Loggly
     public void HandleLog(string logString, string stackTrace, LogType type) {
 
-        //Initialize WWWForm and store log level as a string
-        level = type.ToString ();
-        var loggingForm = new WWWForm();
-    
-        //Add log message to WWWForm
-        loggingForm.AddField("LEVEL", level);
-        loggingForm.AddField("Message", logString);
-        loggingForm.AddField("Stack_Trace", stackTrace);
-    
-        //Add any User, Game, or Device MetaData that would be useful to finding issues later
-        loggingForm.AddField("Device_Model", SystemInfo.deviceModel);
-    	StartCoroutine(SendData(loggingForm));
+      //Initialize WWWForm and store log level as a string
+      level = type.ToString ();
+      var loggingForm = new WWWForm();
+
+      //Add log message to WWWForm
+      loggingForm.AddField("LEVEL", level);
+      loggingForm.AddField("Message", logString);
+      loggingForm.AddField("Stack_Trace", stackTrace);
+
+      //Add any User, Game, or Device MetaData that would be useful to finding issues later
+      loggingForm.AddField("Device_Model", SystemInfo.deviceModel);
+      StartCoroutine(SendData(loggingForm));
 	}
 
-	public IEnumerator SendData(WWWForm form){
-        //Send WWW Form to Loggly, replace TOKEN with your unique ID from Loggly
-        WWW sendLog = new WWW("http://logs-01.loggly.com/inputs/TOKEN/tag/Unity3D", form);
-	    yield return sendLog;
+    public IEnumerator SendData(WWWForm form){
+      //Send WWW Form to Loggly, replace TOKEN with your unique ID from Loggly
+      WWW sendLog = new WWW("http://logs-01.loggly.com/inputs/TOKEN/tag/Unity3D", form);
+      yield return sendLog;
     }
 }

--- a/LogOutputHandler.cs
+++ b/LogOutputHandler.cs
@@ -5,12 +5,12 @@ public class LogOutputHandler : MonoBehaviour {
 
     //Register the HandleLog function on scene start to fire on debug.log events
     public void OnEnable(){
-				Application.logMessageReceived += HandleLog;
+	    Application.logMessageReceived += HandleLog;
     }
 
     //Remove callback when object goes out of scope
-		public void OnDisable(){
-				Application.logMessageReceived -= HandleLog;
+	public void OnDisable(){
+	    Application.logMessageReceived -= HandleLog;
     }
 
     //Create a string to store log level in
@@ -22,20 +22,20 @@ public class LogOutputHandler : MonoBehaviour {
         //Initialize WWWForm and store log level as a string
         level = type.ToString ();
         var loggingForm = new WWWForm();
-
+    
         //Add log message to WWWForm
         loggingForm.AddField("LEVEL", level);
         loggingForm.AddField("Message", logString);
         loggingForm.AddField("Stack_Trace", stackTrace);
-
+    
         //Add any User, Game, or Device MetaData that would be useful to finding issues later
         loggingForm.AddField("Device_Model", SystemInfo.deviceModel);
-				StartCoroutine(SendData(loggingForm));
-		}
+    	StartCoroutine(SendData(loggingForm));
+	}
 
-		public IEnumerator SendData(WWWForm form){
+	public IEnumerator SendData(WWWForm form){
         //Send WWW Form to Loggly, replace TOKEN with your unique ID from Loggly
         WWW sendLog = new WWW("http://logs-01.loggly.com/inputs/TOKEN/tag/Unity3D", form);
-				yield return sendLog;
+	    yield return sendLog;
     }
 }

--- a/LogOutputHandler.js
+++ b/LogOutputHandler.js
@@ -1,0 +1,31 @@
+#pragma strict
+
+//Register the HandleLog function on scene start to fire on debug.log events
+function OnEnable () {
+	Application.logMessageReceived += HandleLog;
+}
+
+//Remove callback when object goes out of scope
+function OnDisable () {
+	Application.logMessageReceived -= HandleLog;
+}
+
+function HandleLog (logString : String, stackTrace : String, type : LogType) {
+  //Initialize WWWForm and store log level as a string
+  var level = type.ToString ();
+  var loggingForm = new WWWForm();
+
+  //Add log message to WWWForm
+  loggingForm.AddField("LEVEL", level);
+  loggingForm.AddField("Message", logString);
+  loggingForm.AddField("Stack_Trace", stackTrace);
+
+  //Add any User, Game, or Device MetaData that would be useful to finding issues later
+  loggingForm.AddField("Device_Model", SystemInfo.deviceModel);
+  SendStuff(loggingForm);
+}
+function SendStuff(form : WWWForm){
+  //Send WWW Form to Loggly, replace TOKEN with your unique ID from Loggly
+  var sendLog = new WWW("http://logs-01.loggly.com/inputs/TOKEN/tag/Unity3D", form);
+  yield sendLog;
+}


### PR DESCRIPTION
Since the current examples do not work with Unity 5.x I made the
following changes to the already existing scripts, and also included a
new UnityScript file to the lot.
- Change #1 Application.RegisterLogCallback(HandleLog);

this has been deprecated in version 5, so I basically changed it to:

public void OnEnable(){
Application.logMessageReceived += HandleLog;
}

public void OnDisable(){
Application.logMessageReceived -= HandleLog;
}

Where we send logs when the object is active and stop when it is
inactive.
- Change #2

/Send WWW Form to Loggly, replace TOKEN with your unique ID from Loggly
var sendLog = new
WWW("http://logs-01.loggly.com/inputs/TOKEN/tag/Unity3D/", loggingForm);
Did two things here. The communication per se (the WWW object) is
handled on a separate function, mainly because of the coroutine
handling in c# and now I force the message to be sent with yield, ergo
removing any concurrency issues. My code:

StartCoroutine(SendData(loggingForm));

public IEnumerator SendData(WWWForm form){
//Send WWW Form to Loggly, replace TOKEN with your unique ID
from Loggly
WWW sendLog = new
WWW("http://logs-01.loggly.com/inputs/TOKEN/tag/Unity3D", form);
yield return sendLog;
}

Have fun :)
